### PR TITLE
Binary format

### DIFF
--- a/lib/App/MoarVM/HeapAnalyzer/Model.pm6
+++ b/lib/App/MoarVM/HeapAnalyzer/Model.pm6
@@ -729,33 +729,34 @@ method !parse-snapshot($snapshot-task) {
                 my int $size = $fh.exactly(1)[0];
 
                 for ^$n {
+                    my @buf;
                     if $size == 54 { # "6"
-                        my @buf := $fh.gimme(18);
-                        ref-kinds.push(@buf.shift);
+                        @buf := $fh.gimme(18);
+                        ref-kinds.push(nqp::shift_i(@buf));
                         ref-indexes.push(readSizedInt64(@buf));
                         ref-tos.push(readSizedInt64(@buf));
-                        $size = @buf.shift;
+                        $size = nqp::shift_i(@buf);
                     }
                     elsif $size == 51 { # "3"
-                        my @buf := $fh.gimme(10);
-                        ref-kinds.push(@buf.shift);
+                        @buf := $fh.gimme(10);
+                        ref-kinds.push(nqp::shift_i(@buf));
                         ref-indexes.push(readSizedInt32(@buf));
                         ref-tos.push(readSizedInt32(@buf));
-                        $size = @buf.shift;
+                        $size = nqp::shift_i(@buf);
                     }
                     elsif $size == 49 { # "1"
-                        my @buf := $fh.gimme(6);
-                        ref-kinds.push(@buf.shift);
+                        @buf := $fh.gimme(6);
+                        ref-kinds.push(nqp::shift_i(@buf));
                         ref-indexes.push(readSizedInt16(@buf));
                         ref-tos.push(readSizedInt16(@buf));
-                        $size = @buf.shift;
+                        $size = nqp::shift_i(@buf);
                     }
                     elsif $size == 48 { # "0"
-                        my @buf := $fh.gimme(4);
-                        ref-kinds.push(@buf.shift);
-                        ref-indexes.push(@buf.shift);
-                        ref-tos.push(@buf.shift);
-                        $size = @buf.shift;
+                        @buf := $fh.gimme(4);
+                        ref-kinds.push(nqp::shift_i(@buf));
+                        ref-indexes.push(nqp::shift_i(@buf));
+                        ref-tos.push(nqp::shift_i(@buf));
+                        $size = nqp::shift_i(@buf);
                     }
                     else {
                         die "unexpected size indicator in references blob: $size ($size.chr())";

--- a/lib/App/MoarVM/HeapAnalyzer/Model.pm6
+++ b/lib/App/MoarVM/HeapAnalyzer/Model.pm6
@@ -652,46 +652,52 @@ method !parse-snapshot($snapshot-task) {
                 await start {
                         do for ^$first-half-count {
                             my @buf := $fh.gimme(2 + 4 + 2 + 8 + 8 + 4);
-                            my uint64 @ = readSizedInt16(@buf),
-                                readSizedInt32(@buf),
-                                readSizedInt16(@buf),
-                                readSizedInt64(@buf),
-                                readSizedInt64(@buf),
-                                readSizedInt32(@buf);
+                            my uint64 @result;
+                            nqp::push_i(@result, readSizedInt16(@buf));
+                            nqp::push_i(@result, readSizedInt32(@buf));
+                            nqp::push_i(@result, readSizedInt16(@buf));
+                            nqp::push_i(@result, readSizedInt64(@buf));
+                            nqp::push_i(@result, readSizedInt64(@buf));
+                            nqp::push_i(@result, readSizedInt32(@buf));
+                            @result;
                         }.Slip
                     },
                     start {
                         do for ^($count - $first-half-count) {
                             my @buf := $second-fh.gimme(2 + 4 + 2 + 8 + 8 + 4);
-                            my uint64 @ = readSizedInt16(@buf),
-                                readSizedInt32(@buf),
-                                readSizedInt16(@buf),
-                                readSizedInt64(@buf),
-                                readSizedInt64(@buf),
-                                readSizedInt32(@buf);
+                            my uint64 @result;
+                            nqp::push_i(@result, readSizedInt16(@buf)),
+                            nqp::push_i(@result, readSizedInt32(@buf)),
+                            nqp::push_i(@result, readSizedInt16(@buf)),
+                            nqp::push_i(@result, readSizedInt64(@buf)),
+                            nqp::push_i(@result, readSizedInt64(@buf)),
+                            nqp::push_i(@result, readSizedInt32(@buf));
+                            @result;
                         }.Slip
                     }
             }
         }
 
         for @collectable-pieces -> @pieces {
-            my int $kind = @pieces.shift;
-            @col-kinds.push($kind);
+            my int $kind = nqp::shift_i(@pieces);
+
+            nqp::push_i(@col-kinds, $kind);
+
             if    $kind == 1 { $num-objects++ }
             elsif $kind == 2 { $num-type-objects++ }
             elsif $kind == 3 { $num-stables++ }
             elsif $kind == 4 { $num-frames++ }
 
-            @col-desc-indexes.push(@pieces.shift);
+            nqp::push_i(@col-desc-indexes, nqp::shift_i(@pieces));
 
-            my int $size = @pieces.shift;
-            @col-size.push($size);
-            my int $unmanaged-size = @pieces.shift;
-            @col-unmanaged-size.push($unmanaged-size);
+            my int $size = nqp::shift_i(@pieces);
+            nqp::push_i(@col-size, $size);
+            my int $unmanaged-size = nqp::shift_i(@pieces);
+            nqp::push_i(@col-unmanaged-size, $unmanaged-size);
             $total-size += $size + $unmanaged-size;
 
-            @col-refs-start.push(@pieces.shift);
-            @col-num-refs.push(@pieces.shift);
+            nqp::push_i(@col-refs-start, nqp::shift_i(@pieces));
+            nqp::push_i(@col-num-refs, nqp::shift_i(@pieces));
         }
         CATCH {
             .say

--- a/lib/App/MoarVM/HeapAnalyzer/Model.pm6
+++ b/lib/App/MoarVM/HeapAnalyzer/Model.pm6
@@ -645,7 +645,7 @@ method !parse-snapshot($snapshot-task) {
         my @collectable-pieces = do {
             if $!version == 1 {
                 $snapshot-task<collectables>.split(";").map({
-                    my uint64 @pieces := .split(",").map(*.Int);
+                    my uint64 @pieces = .split(",").map(*.Int);
                 })
             }
             elsif $!version == 2 {
@@ -701,7 +701,7 @@ method !parse-snapshot($snapshot-task) {
         my @references-pieces = do {
             if $!version == 1 {
                 for $snapshot-task<collectables>.split(";") {
-                    my uint8 @pieces := .split(",").map(*.Int);
+                    my uint8 @pieces = .split(",").map(*.Int);
                     @ref-kinds.push(@pieces.shift);
                     @ref-indexes.push(@pieces.shift);
                     @ref-tos.push(@pieces.shift);

--- a/lib/App/MoarVM/HeapAnalyzer/Model.pm6
+++ b/lib/App/MoarVM/HeapAnalyzer/Model.pm6
@@ -733,30 +733,30 @@ method !parse-snapshot($snapshot-task) {
                     my @buf;
                     if $size == 54 { # "6"
                         @buf := $fh.gimme(18);
-                        ref-kinds.push(nqp::shift_i(@buf));
-                        ref-indexes.push(readSizedInt64(@buf));
-                        ref-tos.push(readSizedInt64(@buf));
+                        nqp::push_i(ref-kinds, nqp::shift_i(@buf));
+                        nqp::push_i(ref-indexes, readSizedInt64(@buf));
+                        nqp::push_i(ref-tos, readSizedInt64(@buf));
                         $size = nqp::shift_i(@buf);
                     }
                     elsif $size == 51 { # "3"
                         @buf := $fh.gimme(10);
-                        ref-kinds.push(nqp::shift_i(@buf));
-                        ref-indexes.push(readSizedInt32(@buf));
-                        ref-tos.push(readSizedInt32(@buf));
+                        nqp::push_i(ref-kinds, nqp::shift_i(@buf));
+                        nqp::push_i(ref-indexes, readSizedInt32(@buf));
+                        nqp::push_i(ref-tos, readSizedInt32(@buf));
                         $size = nqp::shift_i(@buf);
                     }
                     elsif $size == 49 { # "1"
                         @buf := $fh.gimme(6);
-                        ref-kinds.push(nqp::shift_i(@buf));
-                        ref-indexes.push(readSizedInt16(@buf));
-                        ref-tos.push(readSizedInt16(@buf));
+                        nqp::push_i(ref-kinds, nqp::shift_i(@buf));
+                        nqp::push_i(ref-indexes, readSizedInt16(@buf));
+                        nqp::push_i(ref-tos, readSizedInt16(@buf));
                         $size = nqp::shift_i(@buf);
                     }
                     elsif $size == 48 { # "0"
                         @buf := $fh.gimme(4);
-                        ref-kinds.push(nqp::shift_i(@buf));
-                        ref-indexes.push(nqp::shift_i(@buf));
-                        ref-tos.push(nqp::shift_i(@buf));
+                        nqp::push_i(ref-kinds, nqp::shift_i(@buf));
+                        nqp::push_i(ref-indexes, nqp::shift_i(@buf));
+                        nqp::push_i(ref-tos, nqp::shift_i(@buf));
                         $size = nqp::shift_i(@buf);
                     }
                     else {

--- a/lib/App/MoarVM/HeapAnalyzer/Model.pm6
+++ b/lib/App/MoarVM/HeapAnalyzer/Model.pm6
@@ -713,7 +713,7 @@ method !parse-snapshot($snapshot-task) {
         my int @ref-tos;
 
         if $!version == 1 {
-            for $snapshot-task<collectables>.split(";") {
+            for $snapshot-task<references>.split(";") {
                 my uint8 @pieces = .split(",").map(*.Int);
                 @ref-kinds.push(@pieces.shift);
                 @ref-indexes.push(@pieces.shift);

--- a/lib/App/MoarVM/HeapAnalyzer/Model.pm6
+++ b/lib/App/MoarVM/HeapAnalyzer/Model.pm6
@@ -532,8 +532,7 @@ method !parse-types-ver2($fh) {
     my int @repr-name-indexes;
     my int @type-name-indexes;
     for ^$typecount {
-        my @buf := $fh.gimme(24);
-        my $length = readSizedInt64(@buf);
+        my @buf := $fh.gimme(16);
         @repr-name-indexes.push(readSizedInt64(@buf));
         @type-name-indexes.push(readSizedInt64(@buf));
     }

--- a/lib/App/MoarVM/HeapAnalyzer/Model.pm6
+++ b/lib/App/MoarVM/HeapAnalyzer/Model.pm6
@@ -409,8 +409,8 @@ sub readSizedInt16(@buf) {
     #die "expected $bytesize bytes, but got { @buf.elems() }" unless @buf.elems >= $bytesize;
 
     my int64 $result =
-            @buf.shift +
-            @buf.shift +< 8;
+            nqp::add_i(nqp::shift_i(@buf),
+                       nqp::bitshiftl_i(nqp::shift_i(@buf), 8));
 }
 
 submethod BUILD(IO::Path :$file = die "Must construct model with a file") {

--- a/lib/App/MoarVM/HeapAnalyzer/Model.pm6
+++ b/lib/App/MoarVM/HeapAnalyzer/Model.pm6
@@ -398,10 +398,10 @@ sub readSizedInt32($fh) {
     #die "expected $bytesize bytes, but got { @buf.elems() }" unless @buf.elems >= $bytesize;
 
     my int64 $result =
-            @buf.shift +
-            nqp::bitshiftl_i(@buf.shift,  8) +
-            nqp::bitshiftl_i(@buf.shift, 16) +
-            nqp::bitshiftl_i(@buf.shift, 24)
+            nqp::add_i @buf.shift,
+            nqp::add_i nqp::bitshiftl_i(@buf.shift,  8),
+            nqp::add_i nqp::bitshiftl_i(@buf.shift, 16),
+                       nqp::bitshiftl_i(@buf.shift, 24)
 }
 sub readSizedInt16($fh) {
     my $bytesize = 2;

--- a/lib/App/MoarVM/HeapAnalyzer/Model.pm6
+++ b/lib/App/MoarVM/HeapAnalyzer/Model.pm6
@@ -353,7 +353,7 @@ class MyLittleBuffer {
         if $!buffer.elems > $size {
             $!buffer;
         } else {
-            my $newbuf = self.fh.read(4096);
+            my $newbuf := $!fh.read(4096);
             if $!buffer {
                 $!buffer ~= $newbuf;
             } else {
@@ -364,7 +364,7 @@ class MyLittleBuffer {
     }
 
     method seek(|c) {
-        self.fh.seek(|c);
+        $!fh.seek(|c);
         $!buffer = Buf.new();
     }
 

--- a/lib/App/MoarVM/HeapAnalyzer/Model.pm6
+++ b/lib/App/MoarVM/HeapAnalyzer/Model.pm6
@@ -715,7 +715,7 @@ method !parse-snapshot($snapshot-task) {
 
         if $!version == 1 {
             for $snapshot-task<references>.split(";") {
-                my uint8 @pieces = .split(",").map(*.Int);
+                my int @pieces = .split(",").map(*.Int);
                 @ref-kinds.push(@pieces.shift);
                 @ref-indexes.push(@pieces.shift);
                 @ref-tos.push(@pieces.shift);

--- a/lib/App/MoarVM/HeapAnalyzer/Model.pm6
+++ b/lib/App/MoarVM/HeapAnalyzer/Model.pm6
@@ -350,15 +350,10 @@ class MyLittleBuffer {
     has $.fh;
 
     method gimme(int $size) {
-        if $!buffer.elems > $size {
+        if nqp::elems(nqp::decont($!buffer)) > $size {
             $!buffer;
         } else {
-            my $newbuf := $!fh.read(4096);
-            if $!buffer {
-                $!buffer ~= $newbuf;
-            } else {
-                $!buffer = $newbuf;
-            }
+            $!buffer.splice(nqp::elems(nqp::decont($!buffer)), 0, $!fh.read(4096));
             $!buffer;
         }
     }

--- a/lib/App/MoarVM/HeapAnalyzer/Model.pm6
+++ b/lib/App/MoarVM/HeapAnalyzer/Model.pm6
@@ -763,7 +763,7 @@ method !parse-snapshot($snapshot-task) {
                 }
             }
             my $fh := MyLittleBuffer.new(fh => $snapshot-task.tail.open(:r, :bin, :buffer(4096)));
-            $fh.seek($snapshot-task[1], SeekFromBeginning);
+            $fh.seek($snapshot-task[2], SeekFromBeginning);
             die "expected the references header" if $fh.exactly(4).decode("latin1") ne "refs";
             my ($count, $size-per-reference) = readSizedInt64($fh.gimme(8)) xx 2;
             $fh.fh.close;
@@ -773,13 +773,13 @@ method !parse-snapshot($snapshot-task) {
             await start {
                     grab_n_refs_starting_at(
                         $count div 2,
-                        $snapshot-task[1] + 4 + 16,
+                        $snapshot-task[2] + 4 + 16,
                         @ref-kinds, @ref-indexes, @ref-tos);
                 },
                 start {
                     grab_n_refs_starting_at(
                         $count - $count div 2,
-                        $snapshot-task[2] + 4 + 16,
+                        $snapshot-task[1],
                         @ref-kinds-second, @ref-indexes-second, @ref-tos-second);
                 };
             await start { @ref-kinds.splice(+@ref-kinds, 0, @ref-kinds-second); },

--- a/lib/App/MoarVM/HeapAnalyzer/Model.pm6
+++ b/lib/App/MoarVM/HeapAnalyzer/Model.pm6
@@ -730,22 +730,22 @@ method !parse-snapshot($snapshot-task) {
 
                 for ^$n {
                     if $size == 54 { # "6"
-                        my @buf := $fh.gimme(25);
-                        ref-kinds.push(readSizedInt64(@buf));
+                        my @buf := $fh.gimme(18);
+                        ref-kinds.push(@buf.shift);
                         ref-indexes.push(readSizedInt64(@buf));
                         ref-tos.push(readSizedInt64(@buf));
                         $size = @buf.shift;
                     }
                     elsif $size == 51 { # "3"
-                        my @buf := $fh.gimme(13);
-                        ref-kinds.push(readSizedInt32(@buf));
+                        my @buf := $fh.gimme(10);
+                        ref-kinds.push(@buf.shift);
                         ref-indexes.push(readSizedInt32(@buf));
                         ref-tos.push(readSizedInt32(@buf));
                         $size = @buf.shift;
                     }
                     elsif $size == 49 { # "1"
-                        my @buf := $fh.gimme(7);
-                        ref-kinds.push(readSizedInt16(@buf));
+                        my @buf := $fh.gimme(6);
+                        ref-kinds.push(@buf.shift);
                         ref-indexes.push(readSizedInt16(@buf));
                         ref-tos.push(readSizedInt16(@buf));
                         $size = @buf.shift;

--- a/lib/App/MoarVM/HeapAnalyzer/Model.pm6
+++ b/lib/App/MoarVM/HeapAnalyzer/Model.pm6
@@ -519,7 +519,7 @@ submethod BUILD(IO::Path :$file = die "Must construct model with a file") {
 }
 
 method !parse-strings-ver2($fh) {
-    die "expected the strings header" if $fh.exactly(4).decode("utf8") ne "strs";
+    die "expected the strings header" if $fh.exactly(4).decode("latin1") ne "strs";
     my $stringcount = readSizedInt64($fh.gimme(8));
     do for ^$stringcount {
         my $length = readSizedInt64($fh.gimme(8));
@@ -528,7 +528,7 @@ method !parse-strings-ver2($fh) {
     }
 }
 method !parse-types-ver2($fh) {
-    die "expected the types header" if $fh.exactly(4).decode("utf8") ne "type";
+    die "expected the types header" if $fh.exactly(4).decode("latin1") ne "type";
     my ($typecount, $size-per-type) = readSizedInt64($fh.gimme(8)) xx 2;
     my int @repr-name-indexes;
     my int @type-name-indexes;
@@ -540,7 +540,7 @@ method !parse-types-ver2($fh) {
     Types.new(:@repr-name-indexes, :@type-name-indexes, strings => await $!strings-promise);
 }
 method !parse-static-frames-ver2($fh) {
-    die "expected the frames header" if $fh.exactly(4).decode("utf8") ne "fram";
+    die "expected the frames header" if $fh.exactly(4).decode("latin1") ne "fram";
     my ($staticframecount, $size-per-frame) = readSizedInt64($fh.gimme(4)) xx 2;
     my int @name-indexes;
     my int @cuid-indexes;
@@ -646,7 +646,7 @@ method !parse-snapshot($snapshot-task) {
             elsif $!version == 2 {
                 my $fh := MyLittleBuffer.new(fh => $snapshot-task.tail.open(:r, :bin, :buffer(4096)));
                 $fh.seek($snapshot-task[0], SeekFromBeginning);
-                die "expected the collectables header" if $fh.exactly(4).decode("utf8") ne "coll";
+                die "expected the collectables header" if $fh.exactly(4).decode("latin1") ne "coll";
                 my ($count, $size-per-collectable) = readSizedInt64($fh.gimme(8)) xx 2;
 
                 my $startpos = $snapshot-task[0] + 4 + 16;
@@ -764,7 +764,7 @@ method !parse-snapshot($snapshot-task) {
             }
             my $fh := MyLittleBuffer.new(fh => $snapshot-task.tail.open(:r, :bin, :buffer(4096)));
             $fh.seek($snapshot-task[1], SeekFromBeginning);
-            die "expected the references header" if $fh.exactly(4).decode("utf8") ne "refs";
+            die "expected the references header" if $fh.exactly(4).decode("latin1") ne "refs";
             my ($count, $size-per-reference) = readSizedInt64($fh.gimme(8)) xx 2;
             $fh.fh.close;
             my int8 @ref-kinds-second;

--- a/lib/App/MoarVM/HeapAnalyzer/Model.pm6
+++ b/lib/App/MoarVM/HeapAnalyzer/Model.pm6
@@ -481,7 +481,6 @@ submethod BUILD(IO::Path :$file = die "Must construct model with a file") {
         @!unparsed-snapshots = @snapshots;
     }
     elsif $!version == 2 {
-        say "yay, version 2!";
         my $fh = MyLittleBuffer.new(fh => $file.open(:r, :bin));
         constant index-entries = 4;
         $fh.seek(-8 * index-entries, SeekFromEnd);
@@ -492,7 +491,6 @@ submethod BUILD(IO::Path :$file = die "Must construct model with a file") {
 
         sub fh-at($pos) {
             my $fh = MyLittleBuffer.new(fh => $file.open(:r, :bin, :buffer(4096)));
-            say "seeking to $pos";
             $fh.seek($pos, SeekFromBeginning);
             $fh
         }
@@ -519,10 +517,8 @@ submethod BUILD(IO::Path :$file = die "Must construct model with a file") {
 }
 
 method !parse-strings-ver2($fh) {
-    say "reading strings at $fh.tell()";
     die "expected the strings header" if $fh.exactly(4).decode("utf8") ne "strs";
     my $stringcount = readSizedInt64($fh);
-    say "$stringcount strings";
     do for ^$stringcount {
         my $length = readSizedInt64($fh);
         $length ?? $fh.exactly($length).decode("utf8")
@@ -530,10 +526,8 @@ method !parse-strings-ver2($fh) {
     }
 }
 method !parse-types-ver2($fh) {
-    say "reading types at $fh.tell()";
     die "expected the types header" if $fh.exactly(4).decode("utf8") ne "type";
     my ($typecount, $size-per-type) = readSizedInt64($fh) xx 2;
-    say "{ $typecount * $size-per-type } bytes of types";
     my int @repr-name-indexes;
     my int @type-name-indexes;
     for ^$typecount {
@@ -544,10 +538,8 @@ method !parse-types-ver2($fh) {
     Types.new(:@repr-name-indexes, :@type-name-indexes, strings => await $!strings-promise);
 }
 method !parse-static-frames-ver2($fh) {
-    say "reading staticframes at $fh.tell()";
     die "expected the frames header" if $fh.exactly(4).decode("utf8") ne "fram";
     my ($staticframecount, $size-per-frame) = readSizedInt64($fh) xx 2;
-    say "{ $staticframecount * $size-per-frame } bytes of staticframes";
     my int @name-indexes;
     my int @cuid-indexes;
     my int32 @lines;
@@ -651,7 +643,6 @@ method !parse-snapshot($snapshot-task) {
             elsif $!version == 2 {
                 my $fh = MyLittleBuffer.new(fh => $snapshot-task.tail.open(:r, :bin, :buffer(4096)));
                 $fh.seek($snapshot-task[0], SeekFromBeginning);
-                say "parsing snapshot at $fh.tell()";
                 die "expected the collectables header" if $fh.exactly(4).decode("utf8") ne "coll";
                 my ($count, $size-per-collectable) = readSizedInt64($fh) xx 2;
                 do for ^$count {
@@ -711,7 +702,6 @@ method !parse-snapshot($snapshot-task) {
                 dd $snapshot-task;
                 my $fh = MyLittleBuffer.new(fh => $snapshot-task.tail.open(:r, :bin, :buffer(4096)));
                 $fh.seek($snapshot-task[1], SeekFromBeginning);
-                say "parsing references at $fh.tell()";
                 die "expected the references header" if $fh.exactly(4).decode("utf8") ne "refs";
                 my ($count, $size-per-reference) = readSizedInt64($fh) xx 2;
                 for ^$count {


### PR DESCRIPTION
this adds support to moarvm's new binary format.

benefits include:

* no need to load the entire file into a string to split out stuff
* an index at the end allows for fast access into the data tables, including into the middle of references tables
* more parallelism in reading data in
* parsing snapshots is much faster and uses less ram in total
* with a bit of future work, even heap snapshots from crashed processes can be read

on the moarvm side, the new format has the benefit of not having to interact with HLL code in order to get heap snapshots collected, which lets us write each snapshot as soon as we GC'd, and also lets us trigger heap snapshots from inside a running process (for example with gdb, or a debug server kind of deal).